### PR TITLE
[投稿] 身份证核验 — by 霞飞路

### DIFF
--- a/script_library/index.json
+++ b/script_library/index.json
@@ -1,7 +1,7 @@
 {
   "format_version": 1,
-  "data_version": 88,
-  "updated": "2026-04-11T21:12:50.787Z",
+  "data_version": 89,
+  "updated": "2026-04-12T05:10:38Z",
   "announcement": null,
   "categories": [
     {
@@ -1490,6 +1490,30 @@
       "updated": null,
       "status": "active",
       "lines": 236
+    },
+    {
+      "id": "community_身份证核验__by_霞飞路",
+      "name": "身份证核验 — by 霞飞路",
+      "name_en": "身份证核验 — by 霞飞路",
+      "desc": "[投稿] 身份证核验 — by 霞飞路",
+      "desc_en": "[投稿] 身份证核验 — by 霞飞路",
+      "category": "basic",
+      "file": "scripts/basic/script_mnul4nuo.py",
+      "thumbnail": null,
+      "version": 1,
+      "file_type": "py",
+      "author": "社区投稿",
+      "author_en": "社区投稿",
+      "tags": [
+        "community",
+        "basic"
+      ],
+      "requires": [],
+      "min_app_version": "1.5.0",
+      "added": "2026-04-12",
+      "updated": null,
+      "status": "active",
+      "lines": 17
     }
   ]
 }

--- a/script_library/scripts/basic/script_mnul4nuo.py
+++ b/script_library/scripts/basic/script_mnul4nuo.py
@@ -1,0 +1,17 @@
+import re
+def check_id_card(id_str):
+    if len(id_str) != 18 : return False
+    last = id_str[17].upper()
+    if not (last.isdigit() or last == 'X') : return False
+    try:
+        if not re.search(r"^[1-9]\d{5}(18|19|20)\d{2}(0[1-9]|1[0-2])(0[1-9]|[12]\d|3[01])\d{3}[\dXx]$",id_str).group():pass
+    except:
+        return False
+    weights = [7, 9, 10, 5, 8, 4, 2, 1, 6, 3, 7, 9, 10, 5, 8, 4, 2]
+    codes = ['1', '0', 'X', '9', '8', '7', '6', '5', '4', '3', '2']
+    total = sum(int(id_str[i]) * weights[i] for i in range(17))
+    mod = total % 11
+    expected = codes[mod]
+    return last == expected
+if __name__  ==  "__main__":
+    print(check_id_card(input("输入18位完整sfz号码：")))


### PR DESCRIPTION
## 投稿脚本

| 字段 | 内容 |
|------|------|
| **脚本名** | 身份证核验 |
| **作者** | 霞飞路 |
| **分类** | basic |
| **描述** | 基于国标实现的18位身份证严谨校验工具，包含格式校验、日期规则、加权模11校验码验证，兼容大小写X，可输出错误提示，轻量高效。 |
| **行数** | 17 |
| **联系方式** | ifmine900@163.com |

> 合并此 PR 即可上架脚本库，用户刷新即可看到。